### PR TITLE
prefer primary properties as tagged in RIQ

### DIFF
--- a/lib/riq/contact.rb
+++ b/lib/riq/contact.rb
@@ -31,9 +31,20 @@ module RIQ
       get_prop(:name)
     end
 
+    # @!macro [new] prop
+    #   @return [String] the preferred value for $0
+    def primary_name
+      get_primary_prop(:name)
+    end
+
     # @macro prop
     def phone
       get_prop(:phone)
+    end
+
+    # @macro prop
+    def primary_phone
+      get_primary_prop(:phone)
     end
 
     # @macro prop
@@ -42,8 +53,18 @@ module RIQ
     end
 
     # @macro prop
+    def primary_email
+      get_primary_prop(:email)
+    end
+
+    # @macro prop
     def address
       get_prop(:address)
+    end
+
+    # @macro prop
+    def primary_address
+      get_primary_prop(:address)
     end
 
     # Adds property with correct scaffolding
@@ -142,6 +163,18 @@ module RIQ
         @properties[prop].map{|p| p[:value]}
       else
         []
+      end
+    end
+
+    def get_primary_prop(prop)
+      if @properties.include?(prop)
+        preferred = @properties[prop].map do |p|
+          metadata = (p || {})[:metadata]
+          [[(metadata || {})[:primary] == 'true' ? 0 : 1, (metadata || {})[:inactive] == 'true' ? 1 : 0], p[:value]]
+        end
+        preferred.sort_by { |p| p[0] }.first[1]
+      else
+        nil
       end
     end
   end

--- a/test/test_contact.rb
+++ b/test/test_contact.rb
@@ -29,6 +29,34 @@ describe RIQ::Contact do
     end
   end
 
+  describe '#name' do
+    it 'returns an array of property values' do
+      @sammy = create_sammy
+      @sammy.name.must_equal ['Sammynammari', 'Sammy Nammari']
+    end
+  end
+
+  describe '#primary_name' do
+    it 'returns the preferred property value' do
+      @sammy = create_sammy
+      @sammy.primary_name.must_equal 'Sammy Nammari'
+    end
+  end
+
+  describe '#email' do
+    it 'returns an array of property values' do
+      @sammy = create_sammy
+      @sammy.email.must_equal ['sammy.nammari@gmail.com', 'nammari@stanford.edu', 'sammy@relateiq.com']
+    end
+  end
+
+  describe '#primary_email' do
+    it 'returns the preferred property value' do
+      @sammy = create_sammy
+      @sammy.primary_email.must_equal 'sammy@relateiq.com'
+    end
+  end
+
   describe '#save' do 
     it 'should create new contact and delete it' do
       @c = create_blank_contact


### PR DESCRIPTION
This PR adds a few new methods to <tt>RIQ::Contact</tt> in order to retrieve contact details that are marked as the primary (and/or not inactive) property in RIQ.

    contact.primary_email => "sammy@relateiq.com"
    contact.primary_name => "Sammy Nammari"
    # etc